### PR TITLE
Implement IReadOnlyList

### DIFF
--- a/Runtime/ReorderableArray.cs
+++ b/Runtime/ReorderableArray.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace Malee.List {
 
 	[Serializable]
-	public abstract class ReorderableArray<T> : ICloneable, IList<T>, ICollection<T>, IEnumerable<T> {
+	public abstract class ReorderableArray<T> : ICloneable, IList<T>, ICollection<T>, IEnumerable<T>, IReadOnlyList<T> {
 
 		[SerializeField]
 		private List<T> array = new List<T>();


### PR DESCRIPTION
This isn't a super important PR, just thought I'd share this in case it's found to be useful.

> Implemented the IReadOnlyList interface from the ReorderableArray. This will allow users to depend on abstractions and return an IReadOnlyList when useful.

For example

```csharp
[Serializable]
public class MyList : ReorderableArray<int> { }

[Serializable]
public class MyClass
{
    [SerializeField]
    [Reorderable]
    private MyList items = new MyList();

    // No need to expose the underlying MyList type. Also makes it so the list
    // can't be modified.
    public IReadOnlyList<int> Items => items;
}
```